### PR TITLE
Modified the handling of `transformers` model names

### DIFF
--- a/server/data_processing/convenience_corpus.py
+++ b/server/data_processing/convenience_corpus.py
@@ -10,8 +10,8 @@ def get_dir_names(path: Path) -> List[str]:
     return available
 
 @memoize
-def from_base_dir(base_dir:str):
-    return ConvenienceCorpus.from_base_dir(base_dir)
+def from_base_dir(base_dir:str, name:Optional[str]=None):
+    return ConvenienceCorpus.from_base_dir(base_dir,name=name)
 
 @memoize
 def from_model(model_name, corpus_name):
@@ -38,10 +38,9 @@ class ConvenienceCorpus():
 
         self.embeddings_available = files_available(self.embedding_dir)
         self.contexts_available = files_available(self.context_dir)
-
         self.corpus = CorpusDataWrapper(self.corpus_f, self.name)
-        self.embedding_faiss = Indexes(self.embedding_dir)
-        self.context_faiss = ContextIndexes(self.context_dir)
+        self.embedding_faiss = Indexes(self.embedding_dir,self.name)
+        self.context_faiss = ContextIndexes(self.context_dir,self.name)
 
     @classmethod
     def from_base_dir(cls, base_dir:Union[str, Path], name:Optional[str]=None):

--- a/server/data_processing/index_wrapper.py
+++ b/server/data_processing/index_wrapper.py
@@ -2,7 +2,7 @@ from functools import partial
 import faiss
 import numpy as np
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Optional
 from utils.f import memoize
 from transformers import AutoConfig
 
@@ -34,7 +34,7 @@ class Indexes:
     
     Assumes there are files in the folder matching the pattern input
     """
-    def __init__(self, folder, pattern=FAISS_LAYER_PATTERN):
+    def __init__(self, folder, model_name:Optional[str]=None, pattern=FAISS_LAYER_PATTERN):
         self.base_dir = Path(folder)
         self.n_layers = len(list(self.base_dir.glob(pattern))) - 1 # Subtract final output
         self.indexes = [None] * (self.n_layers + 1) # Initialize empty list, adding 1 for input
@@ -42,7 +42,12 @@ class Indexes:
         self.__init_indexes()
 
         # Extract model name from folder hierarchy
-        self.model_name = self.base_dir.parent.parent.stem
+        if model_name is None:
+            self.model_name = self.base_dir.parent.parent.stem
+        # Use passed in model name
+        else:
+            self.model_name = model_name
+
         self.config = get_config(self.model_name)
         self.nheads = self.config.num_attention_heads
         self.hidden_size = self.config.hidden_size

--- a/server/main.py
+++ b/server/main.py
@@ -223,7 +223,12 @@ def search_nearest(payload: api.QueryNearestPayload, kind: str):
 
     try:
         if aconf.has_corpus:
-            cc = from_base_dir(aconf.corpus)
+            if '/' in aconf.model:
+                # If transformer model is in format `user/model`
+                cc = from_base_dir(aconf.corpus,aconf.model)
+            else:
+                cc = from_base_dir(aconf.corpus)
+            
         else:
             model_name = ifnone(aconf.model_name, model)
             cc = from_model(model_name, corpus)


### PR DESCRIPTION
Sometimes, `transformers` models are titled in the format `user/model_name`. In this case, searching by context/embedding wouldn't work because `ExBert` has `transformers` search for just `model_name` due to the reliance upon the directory stemming.

The precise location for this to happen is from [this line in `index_wrapper.py`](https://github.com/bhoov/exbert/blob/0ea81018649bb09b81b54c8bfa444d71e235ba48/server/data_processing/index_wrapper.py#L45)

I dug around and attempted to fix this by checking the model name to see if there is a `/` in it. This is slightly hacky, and there must be a more robust workaround, but this fix works for me. I am using the `"allenai/scibert_scivocab_uncased"` model.